### PR TITLE
fix: date formatting in charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A React application to track and visualize the rewards from running an Algorand 
 
 ## Website
 
-You can access the website at [algonoderewards.com](algonoderewards.com)
+You can access the website at [algonoderewards.com](https://algonoderewards.com)
 
 ![app screenshot](screenshot.png)
 

--- a/src/components/address/charts/cumulative-blocks-chart.tsx
+++ b/src/components/address/charts/cumulative-blocks-chart.tsx
@@ -88,9 +88,9 @@ export default function CumulativeBlocksChart({ blocks }: { blocks: Block[] }) {
   }
 
   const parseISODate = (dateStr: string) => {
-    const arr = dateStr.split("-").map(s => Number(s));
+    const arr = dateStr.split("-").map((s) => Number(s));
     return new Date(arr[0], --arr[1], arr[2]);
-  }
+  };
 
   const formatDate = (dateStr: string) => {
     const date = parseISODate(dateStr);

--- a/src/components/address/charts/cumulative-blocks-chart.tsx
+++ b/src/components/address/charts/cumulative-blocks-chart.tsx
@@ -87,8 +87,13 @@ export default function CumulativeBlocksChart({ blocks }: { blocks: Block[] }) {
     );
   }
 
+  const parseISODate = (dateStr: string) => {
+    const arr = dateStr.split("-").map(s => Number(s));
+    return new Date(arr[0], --arr[1], arr[2]);
+  }
+
   const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr);
+    const date = parseISODate(dateStr);
     return date.toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",
@@ -96,7 +101,7 @@ export default function CumulativeBlocksChart({ blocks }: { blocks: Block[] }) {
   };
 
   const formatTooltipDate = (dateStr: string) => {
-    const date = new Date(dateStr);
+    const date = parseISODate(dateStr);
     return date.toLocaleDateString(undefined, {
       weekday: "long",
       year: "numeric",

--- a/src/components/address/charts/cumulative-rewards-chart.tsx
+++ b/src/components/address/charts/cumulative-rewards-chart.tsx
@@ -116,8 +116,13 @@ export default function CumulativeRewardsChart({
     );
   }
 
+  const parseISODate = (dateStr: string) => {
+    const arr = dateStr.split("-").map(s => Number(s));
+    return new Date(arr[0], --arr[1], arr[2]);
+  }
+
   const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr);
+    const date = parseISODate(dateStr);
     return date.toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",
@@ -125,7 +130,7 @@ export default function CumulativeRewardsChart({
   };
 
   const formatTooltipDate = (dateStr: string) => {
-    const date = new Date(dateStr);
+    const date = parseISODate(dateStr);
     return date.toLocaleDateString(undefined, {
       weekday: "long",
       year: "numeric",

--- a/src/components/address/charts/cumulative-rewards-chart.tsx
+++ b/src/components/address/charts/cumulative-rewards-chart.tsx
@@ -117,9 +117,9 @@ export default function CumulativeRewardsChart({
   }
 
   const parseISODate = (dateStr: string) => {
-    const arr = dateStr.split("-").map(s => Number(s));
+    const arr = dateStr.split("-").map((s) => Number(s));
     return new Date(arr[0], --arr[1], arr[2]);
-  }
+  };
 
   const formatDate = (dateStr: string) => {
     const date = parseISODate(dateStr);


### PR DESCRIPTION
This fixes and issue where time zones with a negative UTC offset (the Americas) would see the wrong date on the charts.